### PR TITLE
Changed from chris-lea ppa repo to using nodesource which replaced it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update
 
 # Install npm
 RUN apt-get install -y software-properties-common && apt-get clean
-RUN add-apt-repository -y ppa:chris-lea/node.js && apt-get update
+RUN apt-get install -y curl && apt-get clean
+RUN curl -sL https://deb.nodesource.com/setup | bash -
 RUN apt-get install -y nodejs && apt-get clean
 
 # Install tiddlywiki


### PR DESCRIPTION
Apparently Chris Lea has gone to work at nodesource and that has changed the way to install node.js on Ubuntu. See second paragraph for Debian and Ubuntu on [Installing Node.js via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions). Further instructions under the [nodesource/distributions](https://github.com/nodesource/distributions) repo.

So I changed the Dockerfile to install curl and then use the new instructions. I was able to create a new TW and browse to it.
