### PR TITLE
Add NODE_MEM env variable to control memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ In this example, the folder `$(pwd)/.tiddlywiki` is used for the data.
 Default auth is `user` / `wiki`
 
 Simply provide the USERNAME and PASSWORD env variables to customise.
+
+# Other settings
+
+If you are in a memory-constrained environment, you can provide the 
+`NODE_MEM` environment variable to specify the memory ceiling (in MB)

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -1,9 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-if [ ! -d /var/lib/tiddlywiki/mywiki ]; then
-  tiddlywiki mywiki --init server
+tiddlywiki_script=$(readlink -f $(which tiddlywiki))
+
+if [ -n "$NODE_MEM" ]; then
+    # Based on rule of thumb from:
+    # http://fiznool.com/blog/2016/10/01/running-a-node-dot-js-app-in-a-low-memory-environment/
+    mem_node_old_space=$((($NODE_MEM*4)/5))
+    NODEJS_V8_ARGS="--max_old_space_size=$mem_node_old_space $NODEJS_V8_ARGS"
 fi
 
-exec tiddlywiki mywiki --server 8080 $:/core/save/all text/plain text/html ${USERNAME:-user} ${PASSWORD:-'wiki'} 0.0.0.0
+if [ ! -d /var/lib/tiddlywiki/mywiki ]; then
+  /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --init server
+fi
+
+exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --server 8080 $:/core/save/all text/plain text/html ${USERNAME:-user} ${PASSWORD:-'wiki'} 0.0.0.0
 


### PR DESCRIPTION
Allow user to configure v8's `max_old_space_size` parameter using NODE_MEM environment variable