### PR TITLE
Use node:alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM ubuntu:14.04
+FROM node:alpine
 
-RUN apt-get update && \
-    apt-get install -y software-properties-common curl && \
-    curl -sL https://deb.nodesource.com/setup | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g tiddlywiki && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN npm install -g tiddlywiki
 
 # Setup wiki volume
 VOLUME /var/lib/tiddlywiki

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ ! -d /var/lib/tiddlywiki/mywiki ]; then


### PR DESCRIPTION
Switch to node:alpine as base image.

* Image size goes from 282MB -> 87MB
* Uses up-to-date base image and nodejs
* Simpler Dockerfile
