### PR TITLE
Serve at uri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ VOLUME /var/lib/tiddlywiki
 WORKDIR /var/lib/tiddlywiki
 
 # Add init-and-run script
+ADD tiddlyweb_host /tiddlyweb_host_template
 ADD init-and-run-wiki /usr/local/bin/init-and-run-wiki
 
 # Meta

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Simply provide the USERNAME and PASSWORD env variables to customise.
 
 If you are in a memory-constrained environment, you can provide the 
 `NODE_MEM` environment variable to specify the memory ceiling (in MB)
+
+To serve the tiddlywiki at a [non-root prefix path](https://tiddlywiki.com/static/Using%2520a%2520custom%2520path%2520prefix%2520with%2520the%2520client-server%2520edition.html) set the `SERVE_URI` environment variable: this variable ''must'' start with a forward slash character. The tiddlywiki will be served by the container at http://<IP>/${SERVE_URI} - the container initialization script takes care of setting the required host configuration tiddler.

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -19,8 +19,7 @@ fi
 
 # Configure the tiddlywiki to be served on a path if it is given
 WEBHOST_TID=/var/lib/tiddlywiki/mywiki/tiddlers/\$__config_tiddlyweb_host.tid
-if [ -n "${SERVE_URI}" ]
-then
+if [ -n "${SERVE_URI}" ]; then
   cp /tiddlyweb_host_template ${WEBHOST_TID}
   echo '$protocol$//$host$'${SERVE_URI}"/" >> ${WEBHOST_TID}
   echo "tiddlywiki will be served at ${SERVE_URI}"

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -24,8 +24,7 @@ if [ -n "${SERVE_URI}" ]; then
   echo '$protocol$//$host$'${SERVE_URI}"/" >> ${WEBHOST_TID}
   echo "tiddlywiki will be served at ${SERVE_URI}"
 else
-  if [ -e ${WEBHOST_TID} ]
-  then
+  if [ -e ${WEBHOST_TID} ]; then
     rm ${WEBHOST_TID}
   fi
 fi

--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -12,7 +12,26 @@ fi
 
 if [ ! -d /var/lib/tiddlywiki/mywiki ]; then
   /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --init server
+
+  mkdir /var/lib/tiddlywiki/mywiki/tiddlers
 fi
 
-exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --server 8080 $:/core/save/all text/plain text/html ${USERNAME:-user} ${PASSWORD:-'wiki'} 0.0.0.0
+
+# Configure the tiddlywiki to be served on a path if it is given
+WEBHOST_TID=/var/lib/tiddlywiki/mywiki/tiddlers/\$__config_tiddlyweb_host.tid
+if [ -n "${SERVE_URI}" ]
+then
+  cp /tiddlyweb_host_template ${WEBHOST_TID}
+  echo '$protocol$//$host$'${SERVE_URI}"/" >> ${WEBHOST_TID}
+  echo "tiddlywiki will be served at ${SERVE_URI}"
+else
+  if [ -e ${WEBHOST_TID} ]
+  then
+    rm ${WEBHOST_TID}
+  fi
+fi
+
+# Start the tiddlywiki server
+
+exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --server 8080 $:/core/save/all text/plain text/html ${USERNAME:-user} ${PASSWORD:-'wiki'} 0.0.0.0 ${SERVE_URI}
 

--- a/tiddlyweb_host
+++ b/tiddlyweb_host
@@ -1,0 +1,4 @@
+title: $:/config/tiddlyweb/host
+type: text/vnd.tiddlywiki
+
+


### PR DESCRIPTION
Enable serving the tiddlywiki at a non-root path

[Serving the tiddlywiki at a non-root path](https://tiddlywiki.com/static/Using%2520a%2520custom%2520path%2520prefix%2520with%2520the%2520client-server%2520edition.html) requires 2 changes: 1 to the node call to tiddlywiki.js, and 1 to a configuration tiddler in the tiddlywiki itself.

This change creates an environment variable SERVE_URI. Setting this variable sets the prefix path argument on the node tiddlywiki.js invocation, and creates and populates the appropriate configuration tiddler.

