### PR TITLE
Make it possible to set empty password

### DIFF
--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -31,5 +31,5 @@ fi
 
 # Start the tiddlywiki server
 
-exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --server 8080 $:/core/save/all text/plain text/html ${USERNAME:-user} ${PASSWORD:-'wiki'} 0.0.0.0 ${SERVE_URI}
+exec /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --server 8080 $:/core/save/all text/plain text/html "${USERNAME:-user}" "${PASSWORD-wiki}" 0.0.0.0 ${SERVE_URI}
 


### PR DESCRIPTION
Hey,
I've been using your Image for quite some time, so thanks for making it!
It's only been running locally, so entering a password was always a hurdle for me to access the wiki. 

Because of Bash substitution, so far it was not possible to set an empty password, and spaces inside password or username would mess with the command execution unless specifically wrapped with escaped quotes.

I decided to leave in the old replacement for usernames (meaning empty turns to default), as an empty username would possibly mess with TiddlyWiki.

Unless it's planned that way, the proposed changes here take those things into account.