### PR TITLE
don't fail to start with docker mounted volume

### DIFF
--- a/init-and-run-wiki
+++ b/init-and-run-wiki
@@ -13,7 +13,7 @@ fi
 if [ ! -d /var/lib/tiddlywiki/mywiki ]; then
   /usr/bin/env node $NODEJS_V8_ARGS $tiddlywiki_script mywiki --init server
 
-  mkdir /var/lib/tiddlywiki/mywiki/tiddlers
+  mkdir -p /var/lib/tiddlywiki/mywiki/tiddlers
 fi
 
 


### PR DESCRIPTION
if external data volume is mounted, don't fail to startup because `/var/lib/tiddlywiki/mywiki/tiddlers` already exists